### PR TITLE
Ability to specify factor vector and data vector for `cliff.delta` function

### DIFF
--- a/R/CliffDelta.R
+++ b/R/CliffDelta.R
@@ -51,8 +51,30 @@
 
 cliff.delta <- function(treatment, ... ) UseMethod("cliff.delta")
 
-cliff.delta.default <- function( treatment, control, conf.level=.95, 
+cliff.delta.default <- function( d, f, conf.level=.95, 
                          use.unbiased=TRUE, use.normal=FALSE, return.dm=FALSE, ...){
+                         
+  if( "character"%in%class(f)|"factor"%in%class(f) ){
+    ## it is data and factor
+    if(length(f)!=length(d)){
+      stop("Data d and factor f must have the same length")
+    }
+    if( "character" %in% class(f)){
+      f = factor(f)
+    }  
+    if(length(levels(f))!=2){
+      stop("Factor f should have only two levels");
+      return;
+    }
+    tc = split(d,f)
+    treatment = tc[[1]]
+    control = tc[[2]]
+  }else{
+    ## it is treatment and control
+    treatment = d
+    control = f
+  }
+
 
   if(conf.level>.9999 | conf.level<.5) stop("conf.level must be within 50% and 99.99%")
   

--- a/man/cliff.delta.Rd
+++ b/man/cliff.delta.Rd
@@ -17,7 +17,7 @@ cliff.delta(treatment, ... )
                                 use.unbiased=TRUE, use.normal=FALSE, 
                                 return.dm=FALSE, ...)
 
-\method{cliff.delta}{default}(treatment, control, conf.level=.95, 
+\method{cliff.delta}{default}(d, f, treatment, control, conf.level=.95, 
                          use.unbiased=TRUE, use.normal=FALSE, 
                          return.dm=FALSE, ...)
 
@@ -30,6 +30,12 @@ numeric vector or ordered factor of data values for the treatment group (see Det
 }
   \item{control}{
 numeric vector or ordered factor of data values for the control group (see Details)
+}
+ \item{d}{
+a numeric vector giving either the data values (if \code{f} is a factor) or the treatment group values (if \code{f} is a numeric vector)
+}
+  \item{f}{
+either a factor with two levels or a numeric vector of values
 }
   \item{conf.level}{
 confidence level of the confidence interval


### PR DESCRIPTION
Have added code (taken from `VD.A`) to check if either of the vectors supplied is a factor; if so, it will treat the input appropriately.