### PR TITLE
Magnitude bug for VD.A in windows (Issue #11)

### DIFF
--- a/R/VD_A.R
+++ b/R/VD_A.R
@@ -50,7 +50,7 @@ VD.A.default <- function(d,f,...){
   res = list(
     method = "Vargha and Delaney A",
     name = "A",
-    magniture = factor(magnitude[findInterval(abs(scaled.A),levels)+1],levels = magnitude,ordered=T),
+    magnitude = factor(magnitude[findInterval(abs(scaled.A),levels)+1],levels = magnitude,ordered=T),
     estimate = A
   )
   class(res) <- "effsize"


### PR DESCRIPTION
Corrected a bug on the VD.A.default function where it would not store
the magnitude due to a typo. Occurred on Windows.